### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,6 +1,9 @@
 # .github/workflows/bandit.yml
 name: Bandit Security Scan
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/Darkelf2024/Darkelf-Browser-v3-PQC/security/code-scanning/1](https://github.com/Darkelf2024/Darkelf-Browser-v3-PQC/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not require write access to repository contents or pull requests, we can set the permissions to `contents: read`. This ensures that the `GITHUB_TOKEN` has only the minimal permissions required to execute the workflow.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs within the workflow. This change does not affect the functionality of the workflow but improves its security posture.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
